### PR TITLE
Update unit test CICD action and bump setup version

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint
-        pip install -r requirements.txt
-    - name: Analysing the code with pylint
-      run: |
-        pylint --fail-under=9.7 pychatter
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+          pip install -r requirements.txt
+      - name: Analysing the code with pylint
+        run: |
+          pylint --fail-under=9.7 pychatter

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -3,32 +3,24 @@ name: Unit tests
 on: [push]
 
 jobs:
-  build-linux:
+  build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env update --file environment.yml --name test-env
-    - name: Install test dependencies
-      working-directory: tests
-      run: |
-        conda install pip
-        pip install -r requirements.txt
-        pip install -e .. 
-    - name: Test with pytest
-      working-directory: tests
-      run: |
-        pytest . 
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
+          pip install -e .
+      - name: Test with pytest
+        working-directory: tests
+        run: |
+          pip install -r requirements.txt
+          pytest .

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ project_dir = Path(__file__).parent
 
 setuptools.setup(
     name="pychatter",
-    version="0.1.2",
+    version="0.1.3",
     description="Local network chat messaging application",
     long_description=project_dir.joinpath("README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
@@ -39,7 +39,10 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Topic :: Communications :: Chat",
+        "Programming Language :: Python :: 3.11",
+        # 3.12 doesn't work with setup.py, see: https://stackoverflow.com/questions/73533994/sub-package-not-importable-after-installation  pylint: disable=line-too-long
+        # "Programming Language :: Python :: 3.12",
         "Typing :: Typed",
+        "Topic :: Communications :: Chat",
     ],
 )


### PR DESCRIPTION
Updates unit test Github Action to remove Conda and replace it with plain pip to make it more robust.

Bumps setup version to 0.1.3.